### PR TITLE
Handle authentication error in 'auth' API

### DIFF
--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -5,7 +5,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
             method: 'GET'
         })
         //@ts-ignore
-        if (res == false) {
+        if (!res.isLoggedIn) {
             return navigateTo("/login")
         }
     }

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -5,7 +5,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
             method: 'GET'
         })
         //@ts-ignore
-        if ((!res.token)) {
+        if (res == false) {
             return navigateTo("/login")
         }
     }

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -5,14 +5,12 @@ export default defineNuxtRouteMiddleware((to, from) => {
             method: 'GET'
         })
         if (!res) {
-            navigateTo("/")
+           return navigateTo("/login")
         }
     }
 
-    try {
-        isAuthenticated()
-    } catch (e) {
-        console.error(e)
-    }
+
+    isAuthenticated()
+
 
 })

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -9,6 +9,10 @@ export default defineNuxtRouteMiddleware((to, from) => {
         }
     }
 
-    isAuthenticated()
+    try {
+        isAuthenticated()
+    } catch (e) {
+        console.error(e)
+    }
 
 })

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -4,9 +4,8 @@ export default defineNuxtRouteMiddleware((to, from) => {
         const res = await $fetch('/api/auth/test', {
             method: 'GET'
         })
-        //@ts-ignore
-        if (!res.isLoggedIn) {
-            return navigateTo("/login")
+        if (!res) {
+            navigateTo("/")
         }
     }
 

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -1,16 +1,23 @@
-export default defineNuxtRouteMiddleware((to, from) => {
+export default defineNuxtRouteMiddleware(async (to, from) => {
 
     async function isAuthenticated() {
-        const res = await $fetch('/api/auth/test', {
-            method: 'GET'
-        })
-        if (!res) {
-           return navigateTo("/login")
+        try {
+            const res = await $fetch('/api/auth/test', {
+                method: 'GET'
+            })
+            if (!res) {
+                return false
+            }
+        } catch (e) {
+            console.error(e)
         }
     }
 
+    console.log(await isAuthenticated())
+    if (!await isAuthenticated()) {
 
-    isAuthenticated()
+        return navigateTo('/login')
+    }
 
 
 })

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -101,7 +101,4 @@ const {data} = await useFetch('/api/user/profile', {
   }
 })
 
-console.log(data)
-
-
 </script>

--- a/server/api/auth/test.get.ts
+++ b/server/api/auth/test.get.ts
@@ -5,9 +5,10 @@ export default defineEventHandler(async (event) => {
 
     try {
         const payload = await requireAuth(event)
+        if (payload === 408) return false
         return (await _useSession(event)).data
-    } catch (e) {
-        return false;
+    } catch (e: any) {
+        console.error(e.message);
     }
 
 })

--- a/server/api/auth/test.get.ts
+++ b/server/api/auth/test.get.ts
@@ -3,7 +3,11 @@ import {_useSession} from "~/server/utils/session";
 
 export default defineEventHandler(async (event) => {
 
-    const payload = await requireAuth(event)
-    return (await _useSession(event)).data
+    try {
+        const payload = await requireAuth(event)
+        return (await _useSession(event)).data
+    } catch (e) {
+        return false;
+    }
 
 })

--- a/server/api/auth/test.get.ts
+++ b/server/api/auth/test.get.ts
@@ -6,7 +6,6 @@ export default defineEventHandler(async (event) => {
     try {
         const payload = await requireAuth(event)
         if (payload === 408) return false
-        return 'OK'
         return (await _useSession(event)).data
     } catch (e: any) {
         console.error(e.message);

--- a/server/api/auth/test.get.ts
+++ b/server/api/auth/test.get.ts
@@ -6,6 +6,7 @@ export default defineEventHandler(async (event) => {
     try {
         const payload = await requireAuth(event)
         if (payload === 408) return false
+        return 'OK'
         return (await _useSession(event)).data
     } catch (e: any) {
         console.error(e.message);

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -21,7 +21,6 @@ export async function clearAuth(event: H3Event) {
 export async function requireAuth(event: H3Event) {
     try {
         const token = (await _useSession(event)).data.token
-        console.log(token)
 
         if (!token) {
             throw createError({

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -19,20 +19,22 @@ export async function clearAuth(event: H3Event) {
 
 
 export async function requireAuth(event: H3Event) {
-    const token = (await _useSession(event)).data.token
-    console.log(token)
+    try {
+        const token = (await _useSession(event)).data.token
+        console.log(token)
 
-    if (!token)
-        return {
-            isLoggedIn: false
+        if (!token) {
+            throw createError({
+                statusCode: 408,
+                statusText: 'Unauthorized! token invalid.'
+            })
         }
 
-    // throw createError({
-    //     statusCode: 401,
-    //     statusText: 'Unauthorized! token invalid.'
-    // })
+        const payload = verifyToken(token)
 
-    const payload = verifyToken(token)
+        return payload
+    } catch (e) {
+        return 408
+    }
 
-    return payload
 }

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -23,12 +23,16 @@ export async function requireAuth(event: H3Event) {
     console.log(token)
 
     if (!token)
-        throw createError({
-            statusCode: 401,
-            statusText: 'Unauthorized! token invalid.'
-        })
+        return {
+            isLoggedIn: false
+        }
+
+    // throw createError({
+    //     statusCode: 401,
+    //     statusText: 'Unauthorized! token invalid.'
+    // })
 
     const payload = verifyToken(token)
 
-   return payload
+    return payload
 }


### PR DESCRIPTION
Added error handling in 'auth' API to prevent unexpected crashes when authentication fails. Modified the way the 'auth' middleware checks for authentication status by comparing the response to 'false' instead of checking for the absence of a token. This prevents redirection to login page when there is an authentication error.