### PR TITLE
Filter user appointments by selected car

### DIFF
--- a/components/userApts.vue
+++ b/components/userApts.vue
@@ -3,6 +3,9 @@ import { format } from "date-fns";
 
 const { data } = useAsyncData('apts', () => $fetch('/api/apts/userapt'))
 
+const {car} = defineProps(['car'])
+
+
 function formatISODate(isoString) {
   const date = new Date(isoString);
   const options = {
@@ -25,20 +28,21 @@ function formatISODate(isoString) {
   <div class="w-full max-w-3xl mx-auto" v-if="data">
     <h2 class="text-2xl font-bold mb-4">Appointment History</h2>
     <div class="space-y-3">
-      <div v-for="apt in data.data" class="bg-white rounded-md shadow-sm overflow-hidden border border-gray-200">
-        <div class="bg-vivid-red text-white p-3">
-          <h3 class="text-lg font-semibold">
-            {{ apt.service }} - {{ apt.carId?.year }} {{ apt.carId?.make }} {{ apt.carId?.model }}
-          </h3>
-        </div>
-        <div class="p-3 space-y-2">
-          <div class="text-gray-700">
-            <span class="font-medium">Date:</span> {{ formatISODate(apt.appointmentDate) }}
+      <div v-for="apt in data.data" >
+        <div v-show="car == apt.carId?._id" class="bg-white rounded-md shadow-sm overflow-hidden border border-gray-200">
+          <div class="bg-vivid-red text-white p-3">
+            <h3 class="text-lg font-semibold">
+              {{ apt.service }} - {{ apt.carId?.year }} {{ apt.carId?.make }} {{ apt.carId?.model }}
+            </h3>
           </div>
-          <div class="text-gray-700">
-            <span class="font-medium">Location:</span> {{ apt.address }}
-          </div>
-          <div>
+          <div class="p-3 space-y-2">
+            <div class="text-gray-700">
+              <span class="font-medium">Date:</span> {{ formatISODate(apt.appointmentDate) }}
+            </div>
+            <div class="text-gray-700">
+              <span class="font-medium">Location:</span> {{ apt.address }}
+            </div>
+            <div>
             <span class="px-2 py-1 rounded-full text-sm font-medium" :class="{
               'bg-yellow-100 text-yellow-800': apt.status === 'Pending',
               'bg-green-100 text-green-800': apt.status === 'Completed',
@@ -46,6 +50,7 @@ function formatISODate(isoString) {
             }">
               Status: {{ apt.status }}
             </span>
+            </div>
           </div>
         </div>
       </div>

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -40,7 +40,7 @@
             </span>
           </div>
           <div>
-            <UserApts v-if="activeTab == 'Appointments'" />
+            <UserApts v-if="activeTab == 'Appointments'" :car="selectedCar._id" />
             <!-- Placeholder for tab content -->
             <!--            <p>{{ activeTab }}</p>-->
           </div>


### PR DESCRIPTION
Updated the UserApts component to filter displayed appointments based on the selected car's id. This is achieved by passing the selected car's id to the `userApts` component from `profile.vue`. Now, only the appointments related to the selected car will be shown in the user's appointment history.